### PR TITLE
fix Only variables should be assigned by reference

### DIFF
--- a/gacl.class.php
+++ b/gacl.class.php
@@ -451,7 +451,7 @@ class gacl {
 				return FALSE;
 			}
 
-			$row =& $rs->FetchRow();
+			$row = $rs->FetchRow();
 
 			/*
 			 * Return ACL ID. This is the key to "hooking" extras like pricing assigned to ACLs etc... Very useful.
@@ -468,7 +468,7 @@ class gacl {
 					$allow = FALSE;
 				}
 
-				$retarr = array('acl_id' => &$row[0], 'return_value' => &$row[2], 'allow' => $allow);
+				$retarr = array('acl_id' => $row[0], 'return_value' => $row[2], 'allow' => $allow);
 			} else {
 				// Permission denied.
 				$retarr = array('acl_id' => NULL, 'return_value' => NULL, 'allow' => FALSE);


### PR DESCRIPTION
In PHP 8 this throws a warning and it seems like the ampersand is not needed there at all anyway. Or what was the purpose of the pointer here?